### PR TITLE
Fix prisma setup on install

### DIFF
--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,9 +1,9 @@
 import { compare } from 'bcryptjs';
-import NextAuth from 'next-auth';
+import NextAuth, { type NextAuthOptions } from 'next-auth';
 import CredentialsProvider from 'next-auth/providers/credentials';
 import { prisma } from '@/app/lib/prisma';
 
-const handler = NextAuth({
+export const authOptions: NextAuthOptions = {
   providers: [
     CredentialsProvider({
       name: 'Credentials',
@@ -61,6 +61,8 @@ const handler = NextAuth({
       return session;
     }
   }
-});
+};
 
-export { handler as GET, handler as POST }; 
+const handler = NextAuth(authOptions);
+
+export { handler as GET, handler as POST };

--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import OpenAI from 'openai';
 import { getServerSession } from 'next-auth';
+import { authOptions } from '../auth/[...nextauth]/route';
 import { prisma } from '@/app/lib/prisma';
 
 interface MedicalArticle {
@@ -20,7 +21,7 @@ const openai = new OpenAI({
 
 export async function POST(request: Request) {
   try {
-    const session = await getServerSession();
+    const session = await getServerSession(authOptions);
     if (!session) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
@@ -94,4 +95,4 @@ Keep the summary focused on the most important insights that would be valuable f
       { status: 500 }
     );
   }
-} 
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,9 +1,10 @@
 import { getServerSession } from 'next-auth';
+import { authOptions } from './api/auth/[...nextauth]/route';
 import SearchInterface from './components/SearchInterface';
 import Link from 'next/link';
 
 export default async function Home() {
-  const session = await getServerSession();
+  const session = await getServerSession(authOptions);
 
   if (!session) {
     return (

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "lint": "next lint",
     "prisma:generate": "prisma generate",
     "prisma:migrate": "prisma migrate dev",
-    "prisma:seed": "node --loader ts-node/esm prisma/seed.ts"
+    "prisma:seed": "node --loader ts-node/esm prisma/seed.ts",
+    "postinstall": "prisma generate"
   },
   "dependencies": {
     "@prisma/client": "^6.8.2",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -6,7 +6,6 @@
 
 generator client {
   provider = "prisma-client-js"
-  output   = "../app/generated/prisma"
 }
 
 datasource db {
@@ -47,6 +46,29 @@ model Search {
   articles        MedicalArticle[]
   aiSummary       String?       @db.Text
   createdAt       DateTime      @default(now())
+}
+
+model Ad {
+  id            String         @id @default(cuid())
+  advertiser    User           @relation(fields: [advertiserId], references: [id])
+  advertiserId  String
+  keywords      String[]
+  budget        Float
+  isActive     Boolean        @default(true)
+  clicks        Int            @default(0)
+  impressions   AdImpression[]
+  createdAt     DateTime       @default(now())
+  updatedAt     DateTime       @updatedAt
+}
+
+model AdImpression {
+  id        String   @id @default(cuid())
+  ad        Ad       @relation(fields: [adId], references: [id])
+  adId      String
+  search    Search   @relation(fields: [searchId], references: [id])
+  searchId  String
+  clicked   Boolean  @default(false)
+  createdAt DateTime @default(now())
 }
 
 enum Role {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from '../app/generated/prisma/index.js';
+import { PrismaClient } from '@prisma/client';
 import { hash } from 'bcryptjs';
 
 const prisma = new PrismaClient();


### PR DESCRIPTION
## Summary
- run prisma generate during package install
- add missing Ad and AdImpression models and remove custom client output
- update seed script to import `@prisma/client`
- export next-auth options for reuse
- trim whitespace in api routes

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm install --offline` *(fails: cache not found)*


------
https://chatgpt.com/codex/tasks/task_e_687fd4992168832c8a0b3c87c5a69dff