### PR TITLE
Configure OpenAI via env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+OPENAI_API_KEY=your-openai-api-key

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ pnpm dev
 bun dev
 ```
 
+### Environment Variables
+
+Copy `.env.example` to `.env` and set `OPENAI_API_KEY` with your OpenAI API key.
+
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.

--- a/src/app/api/ads/click/route.ts
+++ b/src/app/api/ads/click/route.ts
@@ -1,1 +1,19 @@
-import { NextResponse } from 'next/server'; import { prisma } from '@/lib/prisma'; export async function POST(req: Request) { try { const { adId, impressionId } = await req.json(); await prisma.adImpression.update({ where: { id: impressionId }, data: { clicked: true } }); await prisma.ad.update({ where: { id: adId }, data: { clicks: { increment: 1 } } }); return NextResponse.json({ success: true }); } catch (error) { return NextResponse.json({ error: 'Failed to record click' }, { status: 500 }); } }
+import { NextResponse } from 'next/server';
+import { prisma } from '@/app/lib/prisma';
+
+export async function POST(req: Request) {
+  try {
+    const { adId, impressionId } = await req.json();
+    await prisma.adImpression.update({
+      where: { id: impressionId },
+      data: { clicked: true },
+    });
+    await prisma.ad.update({
+      where: { id: adId },
+      data: { clicks: { increment: 1 } },
+    });
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    return NextResponse.json({ error: 'Failed to record click' }, { status: 500 });
+  }
+}

--- a/src/app/api/ads/match/route.ts
+++ b/src/app/api/ads/match/route.ts
@@ -1,1 +1,29 @@
-import { NextResponse } from 'next/server'; import openai from '@/lib/openai'; import { prisma } from '@/lib/prisma'; export async function POST(req: Request) { try { const { query, searchId } = await req.json(); const keywordExtraction = await openai.chat.completions.create({ model: 'gpt-4', messages: [{ role: 'system', content: 'Extract medical keywords as comma-separated list.' }, { role: 'user', content: query }], temperature: 0.3 }); const keywords = keywordExtraction.choices[0].message.content?.split(',').map(k => k.trim()) || []; const matchingAds = await prisma.ad.findMany({ where: { isActive: true, keywords: { hasSome: keywords }, budget: { gt: 0 } }, take: 3 }); await prisma.adImpression.createMany({ data: matchingAds.map(ad => ({ adId: ad.id, searchId, clicked: false })) }); return NextResponse.json({ ads: matchingAds }); } catch (error) { return NextResponse.json({ error: 'Failed to match ads' }, { status: 500 }); } }
+import { NextResponse } from 'next/server';
+import openai from '@/src/lib/openai';
+import { prisma } from '@/app/lib/prisma';
+
+export async function POST(req: Request) {
+  try {
+    const { query, searchId } = await req.json();
+    const keywordExtraction = await openai.chat.completions.create({
+      model: 'gpt-4',
+      messages: [
+        { role: 'system', content: 'Extract medical keywords as comma-separated list.' },
+        { role: 'user', content: query },
+      ],
+      temperature: 0.3,
+    });
+    const keywords =
+      keywordExtraction.choices[0].message.content?.split(',').map((k) => k.trim()) || [];
+    const matchingAds = await prisma.ad.findMany({
+      where: { isActive: true, keywords: { hasSome: keywords }, budget: { gt: 0 } },
+      take: 3,
+    });
+    await prisma.adImpression.createMany({
+      data: matchingAds.map((ad) => ({ adId: ad.id, searchId, clicked: false })),
+    });
+    return NextResponse.json({ ads: matchingAds });
+  } catch (error) {
+    return NextResponse.json({ error: 'Failed to match ads' }, { status: 500 });
+  }
+}

--- a/src/app/api/analytics/route.ts
+++ b/src/app/api/analytics/route.ts
@@ -1,1 +1,22 @@
-import { NextResponse } from 'next/server'; import { prisma } from '@/lib/prisma'; export async function GET(req: Request) { try { const { searchParams } = new URL(req.url); const advertiserId = searchParams.get('advertiserId'); const timeframe = searchParams.get('timeframe') || '7d'; const daysAgo = timeframe === '30d' ? 30 : timeframe === '90d' ? 90 : 7; const startDate = new Date(); startDate.setDate(startDate.getDate() - daysAgo); const metrics = await prisma.adImpression.groupBy({ by: ['createdAt'], where: { ad: { advertiserId }, createdAt: { gte: startDate } }, _count: { id: true }, _sum: { clicked: true } }); return NextResponse.json({ metrics }); } catch (error) { return NextResponse.json({ error: 'Failed to fetch analytics' }, { status: 500 }); } }
+import { NextResponse } from 'next/server';
+import { prisma } from '@/app/lib/prisma';
+
+export async function GET(req: Request) {
+  try {
+    const { searchParams } = new URL(req.url);
+    const advertiserId = searchParams.get('advertiserId');
+    const timeframe = searchParams.get('timeframe') || '7d';
+    const daysAgo = timeframe === '30d' ? 30 : timeframe === '90d' ? 90 : 7;
+    const startDate = new Date();
+    startDate.setDate(startDate.getDate() - daysAgo);
+    const metrics = await prisma.adImpression.groupBy({
+      by: ['createdAt'],
+      where: { ad: { advertiserId }, createdAt: { gte: startDate } },
+      _count: { id: true },
+      _sum: { clicked: true },
+    });
+    return NextResponse.json({ metrics });
+  } catch (error) {
+    return NextResponse.json({ error: 'Failed to fetch analytics' }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary
- import shared OpenAI client in search API
- document environment variable setup
- allow committing `.env.example`

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_688297ee40bc832c80d94b9b7b04a2ad